### PR TITLE
Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ development:
 * `name`: optional - name of the index.  You can (and probably should) have a different name for the index for your test environment.  If not specified, it defaults to the name of the yml file minus the `waistband_` portion, so in the above example, the index name would become `search_#{env}`, where env is your environment variable as defined in `Waistband::Configuration#setup` (determined by `RAILS_ENV` or `RACK_ENV`).
 * `stringify`: optional - determines wether whatever is stored into the index is going to be converted to a string before storage.  Usually false unless you need it to be true for specific cases, like if for some `key => value` pairs the value is of different types some times.
 * `connection`: optional - determines which server/s the index uses.  If not present, it'll use the default connection settings specified in `config/waistband.yml`.
+* `permissions`: optional - determines which permissions to allow on this index, please refer to the [permissions section](#permissions) for more information.
 
 ## Initializer
 
@@ -251,6 +252,30 @@ index.alias_exists?('my_super_events_alias') # => true
 ```
 
 The `alias` methods receives a param to define the alias name.  The same pattern can be used when using index versions.
+
+### Permissions
+
+We've found it safer to tighten up the permissions to determine which actions can be done on each index based on environments.  For example, you might want to allow an index to be created and deleted at will on the development or staging environments, but you probably don't want to allow it to be deleted on production.  To that effect, you're able to set permissions on each index's config file:
+
+```yml
+production:
+    permissions:
+        create: true
+        delete_index: false
+        destroy: true
+        read: true
+        write: true
+```
+
+By default, all permissions are true unless set otherwise.
+
+The specific permissions are:
+
+* `create`: can Waistband create the index?
+* `delete_index`: can Waistband delete the entire index?
+* `destroy`: can Waistband destroy an object in the index?
+* `read`: can Waistband `read`, `find`, or `find_result` in the index?
+* `write`: can Waistband `save` (create or update) an object to the index?
 
 ### Logging
 

--- a/lib/waistband/errors.rb
+++ b/lib/waistband/errors.rb
@@ -1,6 +1,14 @@
 module Waistband
   module Errors
 
+    module Permissions
+      class Create < StandardError; end
+      class Delete < StandardError; end
+      class Destroy < StandardError; end
+      class Read < StandardError; end
+      class Write < StandardError; end
+    end
+
     class IndexExists < StandardError; end
     class IndexNotFound < StandardError; end
     class NoSearchHits < StandardError; end

--- a/lib/waistband/errors.rb
+++ b/lib/waistband/errors.rb
@@ -12,6 +12,7 @@ module Waistband
     class IndexExists < StandardError; end
     class IndexNotFound < StandardError; end
     class NoSearchHits < StandardError; end
+    class UnableToSave < StandardError; end
 
   end
 end

--- a/lib/waistband/errors.rb
+++ b/lib/waistband/errors.rb
@@ -2,11 +2,13 @@ module Waistband
   module Errors
 
     module Permissions
-      class Create < StandardError; end
-      class Delete < StandardError; end
-      class Destroy < StandardError; end
-      class Read < StandardError; end
-      class Write < StandardError; end
+      class PermissionError < StandardError; end
+
+      class Create < PermissionError; end
+      class DeleteIndex < PermissionError; end
+      class Destroy < PermissionError; end
+      class Read < PermissionError; end
+      class Write < PermissionError; end
     end
 
     class IndexExists < StandardError; end

--- a/lib/waistband/index.rb
+++ b/lib/waistband/index.rb
@@ -100,7 +100,7 @@ module Waistband
       raise ::Waistband::Errors::IndexNotFound.new("Index not found")
     end
 
-    def save(*args)
+    def save!(*args)
       check_permission!('write')
 
       body_hash = args.extract_options!
@@ -119,7 +119,17 @@ module Waistband
         body: body_hash
       )
 
-      saved['_id'].present?
+      unless saved['_id'].present?
+        raise ::Waistband::Errors::UnableToSave.new("Unable to save to index: #{config_name}, type: #{_type}, id: #{id}: result: #{saved}")
+      end
+
+      saved
+    end
+
+    def save(*args)
+      save!(*args)
+    rescue ::Waistband::Errors::UnableToSave => ex
+      false
     end
 
     def find(id, options = {})

--- a/lib/waistband/index.rb
+++ b/lib/waistband/index.rb
@@ -92,7 +92,7 @@ module Waistband
     end
 
     def delete!
-      check_permission!('delete')
+      check_permission!('delete_index')
 
       client.indices.delete index: config_name
     rescue Elasticsearch::Transport::Transport::Errors::NotFound => ex
@@ -350,7 +350,7 @@ module Waistband
       end
 
       def check_permission!(permission)
-        raise "::Waistband::Errors::Permissions::#{permission.classify}".constantize.new("Don't have enough permissions to #{permission}") unless check_permission?(permission)
+        raise "::Waistband::Errors::Permissions::#{permission.classify}".constantize.new("Don't have enough permissions to #{permission} on index #{config_name}") unless check_permission?(permission)
       end
 
       def check_permission?(permission)
@@ -359,11 +359,11 @@ module Waistband
 
       def permissions
         @permissions ||= (config['permissions'] || {}).reverse_merge({
-          'create'  => true,
-          'delete'  => true,
-          'destroy' => true,
-          'read'    => true,
-          'write'   => true
+          'create'       => true,
+          'delete_index' => true,
+          'destroy'      => true,
+          'read'         => true,
+          'write'        => true
         }).with_indifferent_access
       end
 

--- a/lib/waistband/index.rb
+++ b/lib/waistband/index.rb
@@ -314,7 +314,15 @@ module Waistband
       end
 
       def default_type_name
+        return default_type_name_from_mappings if default_type_name_from_mappings
         @index_name.singularize
+      end
+
+      def default_type_name_from_mappings
+        @default_type_name_from_mappings ||= begin
+          mappings = (config['mappings'] || {})
+          mappings.keys.first
+        end
       end
 
       def settings

--- a/spec/config/waistband/waistband_events_with_env_permissions.yml
+++ b/spec/config/waistband/waistband_events_with_env_permissions.yml
@@ -1,11 +1,11 @@
 development: &DEV
   name: events
   permissions:
-    create: false
-    delete_index: false
-    destroy: false
-    read: false
-    write: false
+    create: true
+    delete_index: true
+    destroy: true
+    read: true
+    write: true
   stringify: true
   settings:
     index:
@@ -19,3 +19,9 @@ development: &DEV
 test:
   <<: *DEV
   name: events_test
+  permissions:
+    create: true
+    delete_index: false
+    destroy: true
+    read: true
+    write: true

--- a/spec/config/waistband/waistband_events_with_permissions.yml
+++ b/spec/config/waistband/waistband_events_with_permissions.yml
@@ -1,0 +1,21 @@
+development: &DEV
+  name: events
+  permissions:
+    create: false
+    delete: false
+    destroy: false
+    read: false
+    write: false
+  stringify: true
+  settings:
+    index:
+      number_of_shards: 1
+      number_of_replicas: 1
+  mappings:
+    event:
+      _source:
+        includes: ["*"]
+
+test:
+  <<: *DEV
+  name: events_test

--- a/spec/config/waistband/waistband_no_mappings.yml
+++ b/spec/config/waistband/waistband_no_mappings.yml
@@ -1,0 +1,8 @@
+development: &DEV
+  settings:
+    index:
+      number_of_shards: 1
+      number_of_replicas: 1
+
+test:
+  <<: *DEV

--- a/spec/config/waistband/waistband_search.yml
+++ b/spec/config/waistband/waistband_search.yml
@@ -6,7 +6,7 @@ development: &DEV
       number_of_shards: 1
       number_of_replicas: 1
   mappings:
-    event:
+    search:
       _source:
         includes: ["*"]
 

--- a/spec/lib/body_size_logging_spec.rb
+++ b/spec/lib/body_size_logging_spec.rb
@@ -2,18 +2,13 @@ require 'spec_helper'
 
 describe Waistband::Index do
 
+  let(:index) { Waistband::Index.new('search') }
+
   before do
-    @original_logger = Waistband.config.logger
     Waistband.config.logger = FakeLog.new
   end
 
-  after do
-    Waistband.config.logger = @original_logger
-  end
-
   it "logs a warning when the body size of a document to store is too large" do
-    index = Waistband::Index.new('search')
-
     thing_string = ("a" * 150_000).to_s
 
     expect(Waistband.config.logger).to receive(:warn).with(

--- a/spec/lib/body_size_logging_spec.rb
+++ b/spec/lib/body_size_logging_spec.rb
@@ -2,13 +2,18 @@ require 'spec_helper'
 
 describe Waistband::Index do
 
-  let(:index) { Waistband::Index.new('search') }
-
   before do
+    @original_logger = Waistband.config.logger
     Waistband.config.logger = FakeLog.new
   end
 
+  after do
+    Waistband.config.logger = @original_logger
+  end
+
   it "logs a warning when the body size of a document to store is too large" do
+    index = Waistband::Index.new('search')
+
     thing_string = ("a" * 150_000).to_s
 
     expect(Waistband.config.logger).to receive(:warn).with(

--- a/spec/lib/index/index_spec.rb
+++ b/spec/lib/index/index_spec.rb
@@ -86,7 +86,7 @@ describe Waistband::Index do
   describe "storing" do
 
     it "stores data" do
-      expect(index.save('__test_write', {'ok' => 'yeah'})).to be true
+      expect(index.save('__test_write', {'ok' => 'yeah'})).to be_present
       expect(index.read('__test_write')).to eql({
         '_id' => '__test_write',
         '_index' => 'events_test',

--- a/spec/lib/index/permissions_spec.rb
+++ b/spec/lib/index/permissions_spec.rb
@@ -4,11 +4,12 @@ describe "Waistband::Index - Permissions" do
 
   let(:index)  { Waistband::Index.new('events') }
   let(:index2) { Waistband::Index.new('events_with_permissions') }
+  let(:index3) { Waistband::Index.new('events_with_env_permissions') }
 
   it "detaults all permissions to true when not found" do
     expect(index.send(:permissions)).to eql({
       'create' => true,
-      'delete' => true,
+      'delete_index' => true,
       'destroy' => true,
       'read' => true,
       'write' => true
@@ -18,10 +19,20 @@ describe "Waistband::Index - Permissions" do
   it "allows overriding permissions" do
     expect(index2.send(:permissions)).to eql({
       'create' => false,
-      'delete' => false,
+      'delete_index' => false,
       'destroy' => false,
       'read' => false,
       'write' => false
+    })
+  end
+
+  it "allows environment specific overriding" do
+    expect(index3.send(:permissions)).to eql({
+      'create' => true,
+      'delete_index' => false,
+      'destroy' => true,
+      'read' => true,
+      'write' => true
     })
   end
 
@@ -34,7 +45,7 @@ describe "Waistband::Index - Permissions" do
   it "doesn't allow deleting" do
     expect {
       index2.delete!
-    }.to raise_error(Waistband::Errors::Permissions::Delete)
+    }.to raise_error(Waistband::Errors::Permissions::DeleteIndex)
   end
 
   it "doesn't allow destroying" do

--- a/spec/lib/index/permissions_spec.rb
+++ b/spec/lib/index/permissions_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe "Waistband::Index - Permissions" do
+
+  let(:index)  { Waistband::Index.new('events') }
+  let(:index2) { Waistband::Index.new('events_with_permissions') }
+
+  it "detaults all permissions to true when not found" do
+    expect(index.send(:permissions)).to eql({
+      'create' => true,
+      'delete' => true,
+      'destroy' => true,
+      'read' => true,
+      'write' => true
+    })
+  end
+
+  it "allows overriding permissions" do
+    expect(index2.send(:permissions)).to eql({
+      'create' => false,
+      'delete' => false,
+      'destroy' => false,
+      'read' => false,
+      'write' => false
+    })
+  end
+
+  it "doesn't allow writing" do
+    expect {
+      index2.create!
+    }.to raise_error(Waistband::Errors::Permissions::Create)
+  end
+
+  it "doesn't allow deleting" do
+    expect {
+      index2.delete!
+    }.to raise_error(Waistband::Errors::Permissions::Delete)
+  end
+
+  it "doesn't allow destroying" do
+    expect {
+      index2.destroy!('123')
+    }.to raise_error(Waistband::Errors::Permissions::Destroy)
+  end
+
+  it "doesn't allow reading" do
+    expect {
+      index2.read!('123')
+    }.to raise_error(Waistband::Errors::Permissions::Read)
+  end
+
+  it "doesn't allow finding" do
+    expect {
+      index2.find!('123')
+    }.to raise_error(Waistband::Errors::Permissions::Read)
+  end
+
+  it "doesn't allow read_resulting" do
+    expect {
+      index2.read_result!('123')
+    }.to raise_error(Waistband::Errors::Permissions::Read)
+  end
+
+  it "doesn't allow writing" do
+    expect {
+      index2.save!('123', {ok: 'nook'})
+    }.to raise_error(Waistband::Errors::Permissions::Write)
+  end
+
+end

--- a/spec/lib/index/type_spec.rb
+++ b/spec/lib/index/type_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe "Waistband::Index - Type" do
+
+  it "defaults to the first type we find in the mappings if possible" do
+    index = Waistband::Index.new('events_no_name')
+    expect(index.send(:default_type_name)).to eql 'event'
+  end
+
+  it "defaults to singular index name if no mappings" do
+    index = Waistband::Index.new('no_mappings')
+    expect(index.send(:default_type_name)).to eql 'no_mapping'
+  end
+
+end

--- a/spec/lib/index_multi_connection_spec.rb
+++ b/spec/lib/index_multi_connection_spec.rb
@@ -22,7 +22,7 @@ describe Waistband::Index do
   it "works" do
     index.delete
     index.create
-    index.save('testing123', {ok: 'yeah'})
+    saved = index.save('testing123', {ok: 'yeah'})
     index.refresh
     data = index.read('testing123')
     expect(data['_source']['ok']).to eql 'yeah'

--- a/spec/support/fake_log.rb
+++ b/spec/support/fake_log.rb
@@ -9,4 +9,5 @@ class FakeLog
   def debug(val); end
   def fatal(val); end
   def warn(val); end
+  def error(val);  end
 end


### PR DESCRIPTION
Permission handling and better type defaults.

Allow setting permissions to the index config file like so:

```yml
permissions:
  create: false
  delete_index: false
  destroy: false
  read: false
  write: false
```

Calling methods that depend on this permission will raise appropriate exceptions.  these permissions can be different from environment to environment.