### PR TITLE
expose the type option when searching

### DIFF
--- a/lib/waistband/index.rb
+++ b/lib/waistband/index.rb
@@ -195,10 +195,10 @@ module Waistband
     def search(body_hash)
       page, page_size = get_page_info body_hash
       body_hash       = parse_search_body(body_hash)
-      type            = body_hash.delete(:type)
+      _type           = body_hash.delete(:_type)
       search_hash     = {index: config_name, body: body_hash}
 
-      search_hash[:type] = type if type
+      search_hash[:type] = _type if _type
       search_hash[:from] = body_hash[:from] if body_hash[:from]
       search_hash[:size] = body_hash[:size] if body_hash[:size]
 

--- a/lib/waistband/index.rb
+++ b/lib/waistband/index.rb
@@ -195,8 +195,10 @@ module Waistband
     def search(body_hash)
       page, page_size = get_page_info body_hash
       body_hash       = parse_search_body(body_hash)
+      type            = body_hash.delete(:type)
       search_hash     = {index: config_name, body: body_hash}
 
+      search_hash[:type] = type if type
       search_hash[:from] = body_hash[:from] if body_hash[:from]
       search_hash[:size] = body_hash[:size] if body_hash[:size]
 

--- a/spec/lib/index/index_spec.rb
+++ b/spec/lib/index/index_spec.rb
@@ -86,7 +86,7 @@ describe Waistband::Index do
     end
 
     it "does not blow up when an index type is specified" do
-      expect{ index.search({type: 'event'}) }.to_not raise_error
+      expect{ index.search({_type: 'event'}) }.to_not raise_error
     end
 
   end

--- a/spec/lib/index/index_spec.rb
+++ b/spec/lib/index/index_spec.rb
@@ -69,18 +69,26 @@ describe Waistband::Index do
     expect(response['acknowledged']).to be true
   end
 
-  it "proxies to the client's search" do
-    result = index.search({})
-    expect(result).to be_a Waistband::SearchResults
-    expect(result.took).to be_present
-    expect(result.hits).to be_an Array
-  end
-
   it "correctly sets hosts" do
     expect(index.client.send(:hosts)).to eql([
       {"host" => "localhost", "port" => 9200, "protocol" => "http"},
       {"host" => "127.0.0.1", "port" => 9200, "protocol" => "http"}
     ])
+  end
+
+  describe "searching" do
+
+    it "proxies to the client's search" do
+      result = index.search({})
+      expect(result).to be_a Waistband::SearchResults
+      expect(result.took).to be_present
+      expect(result.hits).to be_an Array
+    end
+
+    it "does not blow up when an index type is specified" do
+      expect{ index.search({type: 'event'}) }.to_not raise_error
+    end
+
   end
 
   describe "storing" do


### PR DESCRIPTION
With the elasticsearch-ruby gem, it's possible to specify index types when searching.
Example:
```
elasticsearch_client.search(index: "my_index", type: "some_type", body: query)
elasticsearch_client.search(index: "my_index", type: "some_type,another_type", body: query)
```
It would be nice if waistband exposed this option so that this works:
```
search = index.search({
    query: {
        term: { hidden: false }
    },
    type: "some_type"
})
```
That's what this PR does.
