### PR TITLE
Pass host config as a Hash with Symbols

### DIFF
--- a/lib/waistband/client.rb
+++ b/lib/waistband/client.rb
@@ -53,11 +53,10 @@ module Waistband
 
     private
 
-      def hosts
-        @hosts ||= @servers.map do |server_name, config|
-          config
-        end
+    def hosts
+      @hosts ||= @servers.map do |server_name, config|
+        config.each_with_object({}) { |(key, value), obj| obj[key.to_sym] = value }
       end
-
+    end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -48,6 +48,10 @@ describe Waistband::Configuration do
   end
 
   describe 'hosts' do
+    it "formats host Hashes to use Symbolized keys" do
+      keys = config.client.send(:hosts).first.keys
+      expect(keys.first).to be_a(Symbol)
+    end
 
     it "returns array of all available servers' configs" do
       hosts = config.client.send(:hosts)
@@ -55,9 +59,9 @@ describe Waistband::Configuration do
       expect(hosts.size).to eql 2
 
       hosts.each_with_index do |server, i|
-        expect(server['host']).to match(/127\.0\.0\.1|localhost/)
-        expect(server['port']).to eql 9200
-        expect(server['protocol']).to eql 'http'
+        expect(server[:host]).to match(/127\.0\.0\.1|localhost/)
+        expect(server[:port]).to eql 9200
+        expect(server[:protocol]).to eql 'http'
       end
     end
 

--- a/spec/lib/index/index_spec.rb
+++ b/spec/lib/index/index_spec.rb
@@ -71,8 +71,8 @@ describe Waistband::Index do
 
   it "correctly sets hosts" do
     expect(index.client.send(:hosts)).to eql([
-      {"host" => "localhost", "port" => 9200, "protocol" => "http"},
-      {"host" => "127.0.0.1", "port" => 9200, "protocol" => "http"}
+      {host: "localhost", port: 9200, protocol: "http"},
+      {host: "127.0.0.1", port: 9200, protocol: "http"}
     ])
   end
 

--- a/spec/lib/index_multi_connection_spec.rb
+++ b/spec/lib/index_multi_connection_spec.rb
@@ -8,11 +8,13 @@ describe Waistband::Index do
   it "grabs connection data from the index's settings" do
     expect(client).to be_a(::Waistband::Client)
     expect(client.connection).to be_a(::Elasticsearch::Transport::Client)
-    expect(client.instance_variable_get('@servers')).to eql({"server1"=>{"host"=>"127.0.0.1", "port"=>9200, "protocol"=>"http"}})
+    expect(client.instance_variable_get('@servers'))
+      .to eql({"server1"=>{"host"=>"127.0.0.1", "port"=>9200, "protocol"=>"http"}})
   end
 
   it "correctly sets hosts" do
-    expect(client.send(:config_hash)[:hosts]).to eql([{"host"=>"127.0.0.1", "port"=>9200, "protocol"=>"http"}])
+    expect(client.send(:config_hash)[:hosts])
+      .to eql([{host: "127.0.0.1", port: 9200, protocol: "http"}])
   end
 
   it "exposes servers correctly" do
@@ -22,7 +24,7 @@ describe Waistband::Index do
   it "works" do
     index.delete
     index.create
-    saved = index.save('testing123', {ok: 'yeah'})
+    index.save('testing123', {ok: 'yeah'})
     index.refresh
     data = index.read('testing123')
     expect(data['_source']['ok']).to eql 'yeah'


### PR DESCRIPTION
Version 6.X of `elasticsearch-transport` gem expects all configs to be
passed as a Hash with keys as Symbols. Later versions introduce their
own coercion.

This change will help ensure compatibility regardless of  `elasticsearch-transport` version.