### PR TITLE
Implement Partial Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ index.find('my_data') # => {"important"=>true, "valuable"=>{"always"=>true}}
 # reading with all the internal data
 index.read('my_data') # => {'_id' => '123123', '_source' => {"important"=>true, "valuable"=>{"always"=>true}}, ...}
 
+# partial updating
+index.save('my_data', {'important' => true, 'valuable' => {'always' => true}}) # => true
+index.update('my_data', {'important' => false }) # => true
+index.read('my_data') # => {'_id' => '123123', '_source' => {"important"=>false, "valuable"=>{"always"=>true}}, ...}
+
 # deleting
 index.destroy('my_data') # => "{\"ok\":true,\"found\":true,\"_index\":\"search\",\"_type\":\"search\",\"_id\":\"my_data\",\"_version\":2}"
 

--- a/lib/waistband/errors.rb
+++ b/lib/waistband/errors.rb
@@ -15,6 +15,7 @@ module Waistband
     class IndexNotFound < StandardError; end
     class NoSearchHits < StandardError; end
     class UnableToSave < StandardError; end
+    class UnableToUpdate < StandardError; end
 
   end
 end

--- a/lib/waistband/index.rb
+++ b/lib/waistband/index.rb
@@ -162,7 +162,7 @@ module Waistband
 
     def update(*args)
       update!(*args)
-    rescue ::Waistband::Errors::UnableToUpdate => ex
+    rescue ::Waistband::Errors::UnableToUpdate
       false
     end
 

--- a/spec/lib/index/index_spec.rb
+++ b/spec/lib/index/index_spec.rb
@@ -92,7 +92,6 @@ describe Waistband::Index do
   end
 
   describe "storing" do
-
     it "stores data" do
       expect(index.save('__test_write', {'ok' => 'yeah'})).to be_present
       expect(index.read('__test_write')).to eql({
@@ -101,6 +100,19 @@ describe Waistband::Index do
         '_source' => {'ok' => 'yeah'},
         '_type' => 'event',
         '_version' => 1,
+        'found' => true
+      })
+    end
+
+    it "partially updates data" do
+      expect(index.save('__test_write', {'ok' => 'yeah', 'not_ok' => 'yeah'})).to be_present
+      expect(index.update('__test_write', {'not_ok' => 'no'})).to be_present
+      expect(index.read('__test_write')).to eql({
+        '_id' => '__test_write',
+        '_index' => 'events_test',
+        '_source' => {'ok' => 'yeah', 'not_ok' => 'no'},
+        '_type' => 'event',
+        '_version' => 2,
         'found' => true
       })
     end

--- a/spec/lib/index/index_spec.rb
+++ b/spec/lib/index/index_spec.rb
@@ -104,7 +104,7 @@ describe Waistband::Index do
       })
     end
 
-    it "partially updates data" do
+    it "can partially updates documents" do
       expect(index.save('__test_write', {'ok' => 'yeah', 'not_ok' => 'yeah'})).to be_present
       expect(index.update('__test_write', {'not_ok' => 'no'})).to be_present
       expect(index.read('__test_write')).to eql({


### PR DESCRIPTION
This PR implements partial updates using ES's [update api](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/docs-update.html). 

Adds a new `Waistband::Index#update` method that follows the same signature as `Waistband::Index#save`.